### PR TITLE
docs: reference standalone strategy (StartStandalone + Wait)

### DIFF
--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -61,3 +61,9 @@ cd ..
 git add sdk
 git commit -m "chore: bump sdk submodule"
 ```
+
+## Reference strategy
+
+See [`examples/reference-standalone`](./examples/reference-standalone) for the blessed
+`StartStandalone` + `Wait` process host. Copy that pattern for private strategies.
+

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ cd wisp
 
 Monorepo layout (CLI + sdk submodule): see [MONOREPO.md](./MONOREPO.md). Connectors are a separate module.
 
+Blessed strategy packaging: [`examples/reference-standalone`](./examples/reference-standalone) (`StartStandalone` + `Wait`).
+
 ```bash
 # legacy one-liner without submodules still installs the CLI module only:
 git clone https://github.com/wisp-trading/wisp

--- a/examples/reference-standalone/README.md
+++ b/examples/reference-standalone/README.md
@@ -1,0 +1,35 @@
+# Reference standalone strategy
+
+**Blessed packaging path** for Wisp strategies.
+
+## Contract
+
+```text
+fx.Start → runtime.StartStandalone(strategy, configDir, wispYml) → runtime.Wait()
+```
+
+- `Wait()` blocks until **SIGINT/SIGTERM** or monitoring **POST /shutdown**
+- Then performs a single clean `Stop` and the process exits
+- Do **not** write your own signal loop that ignores `/shutdown`
+
+## Run (when connectors build is green)
+
+```bash
+# from monorepo root (wisp + sdk submodule)
+cd examples/reference-standalone
+# copy/adapt config as needed
+go run . -config . -wisp ../../wisp.yml
+```
+
+Until `connectors` hyperliquid is fixed ([connectors#52](https://github.com/wisp-trading/connectors/issues/52)),
+full `go run` may fail to compile the live Module. The source below is still the
+canonical pattern for strategy binaries (including private alpha).
+
+## Files
+
+| File | Role |
+|------|------|
+| `main.go` | Process host: fx + StartStandalone + Wait |
+| `strategy.go` | Minimal self-directed strategy |
+
+Private strategies should copy this pattern; they stay out of this repo.

--- a/examples/reference-standalone/main.go
+++ b/examples/reference-standalone/main.go
@@ -1,0 +1,62 @@
+// Reference process host for Wisp strategies.
+//
+// Pattern (blessed):
+//
+//	fx app Start → runtime.StartStandalone → runtime.Wait
+//
+// Wait unifies OS signals and monitoring HTTP /shutdown so the process always exits.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+
+	"github.com/wisp-trading/connectors/pkg/connectors"
+	"github.com/wisp-trading/sdk/pkg/types/runtime"
+	"github.com/wisp-trading/sdk/pkg/types/strategy"
+	"github.com/wisp-trading/sdk/wisp"
+	"go.uber.org/fx"
+)
+
+func main() {
+	configDir := flag.String("config", ".", "strategy config directory")
+	wispYml := flag.String("wisp", "wisp.yml", "path to wisp.yml / exchanges config root")
+	flag.Parse()
+
+	ctx := context.Background()
+
+	var (
+		rt    runtime.Runtime
+		strat strategy.Strategy
+	)
+
+	app := fx.New(
+		connectors.Module,
+		wisp.Module,
+		fx.Provide(NewReferenceStrategy),
+		fx.Populate(&rt, &strat),
+		fx.NopLogger,
+	)
+
+	if err := app.Start(ctx); err != nil {
+		log.Fatalf("fx start: %v", err)
+	}
+	defer func() {
+		if err := app.Stop(ctx); err != nil {
+			log.Printf("fx stop: %v", err)
+		}
+	}()
+
+	if err := rt.StartStandalone(strat, *configDir, *wispYml); err != nil {
+		log.Fatalf("StartStandalone: %v", err)
+	}
+
+	log.Println("strategy started — waiting for signal or remote /shutdown")
+	if err := rt.Wait(); err != nil {
+		log.Printf("Wait: %v", err)
+		os.Exit(1)
+	}
+	log.Println("shutdown complete")
+}

--- a/examples/reference-standalone/strategy.go
+++ b/examples/reference-standalone/strategy.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/wisp-trading/sdk/pkg/types/strategy"
+	"github.com/wisp-trading/sdk/pkg/types/wisp"
+)
+
+// ReferenceStrategy is a minimal self-directed strategy for packaging demos.
+// It does not place orders — it only proves the process lifecycle.
+type ReferenceStrategy struct {
+	strategy.BaseStrategy
+	k wisp.Wisp
+}
+
+func NewReferenceStrategy(k wisp.Wisp) strategy.Strategy {
+	s := &ReferenceStrategy{k: k}
+	s.BaseStrategy = *strategy.NewBaseStrategy(strategy.BaseStrategyConfig{
+		Name: "reference-standalone",
+	})
+	return s
+}
+
+func (s *ReferenceStrategy) Start(ctx context.Context) error {
+	return s.StartWithRunner(ctx, s.run)
+}
+
+func (s *ReferenceStrategy) run(ctx context.Context) {
+	s.k.Log().Info("reference-standalone: running (Ctrl+C or POST /shutdown to stop)")
+	t := time.NewTicker(30 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			s.k.Log().Info("reference-standalone: context done")
+			return
+		case <-t.C:
+			s.k.Log().Info("reference-standalone: heartbeat")
+		}
+	}
+}


### PR DESCRIPTION
Adds examples/reference-standalone as the public blessed packaging pattern. Links from README and MONOREPO.md.