### PR TITLE
feat: standalone strategy spawn + green-path smoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,17 @@ debug/
 
 # Credentials (global exchange config)
 exchanges.yml
+
+# built strategy binaries
+strategies/*/*
+!strategies/*/
+!strategies/*/*.
+examples/reference-standalone/reference-standalone
+bin/
+bin/
+examples/reference-standalone/reference-standalone
+**/reference-standalone
+
+# Build outputs
+/bin/
+examples/reference-standalone/reference-standalone

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -67,3 +67,11 @@ git commit -m "chore: bump sdk submodule"
 See [`examples/reference-standalone`](./examples/reference-standalone) for the blessed
 `StartStandalone` + `Wait` process host. Copy that pattern for private strategies.
 
+## Green path
+
+```bash
+make smoke   # builds CLI + examples/reference-standalone binary
+```
+
+TUI Start Live compiles `strategies/<name>/` as a **standalone binary** when `main.go` exists.
+

--- a/Makefile
+++ b/Makefile
@@ -1,98 +1,24 @@
-.PHONY: build install test clean run-init run-backtest run-interactive help setup
+.PHONY: help submodules build smoke test
 
-# Setup development environment (run once after cloning)
-setup:
-	@echo "🔧 Configuring git hooks..."
-	@git config core.hooksPath .githooks
-	@chmod +x .githooks/pre-commit
-	@chmod +x .git/hooks/pre-commit 2>/dev/null || true
-	@echo "📦 Installing golangci-lint..."
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin
-	@echo "✅ Setup complete"
-
-# Build the CLI binary
-build:
-	@echo "🔨 Building Wisp CLI..."
-	@go build -o wisp .
-	@echo "✅ Build complete: ./wisp"
-
-# Install the CLI to $GOPATH/bin
-install:
-	@echo "📦 Installing Wisp CLI..."
-	@go build -o $(shell go env GOPATH)/bin/wisp .
-	@echo "✅ Installed to $(shell go env GOPATH)/bin/wisp"
-	@echo "💡 Run 'wisp --help' to get started"
-
-# Run tests
-test:
-	@echo "🧪 Running tests..."
-	@go test ./... -v
-
-# Clean build artifacts
-clean:
-	@echo "🧹 Cleaning..."
-	@rm -f wisp
-	@rm -rf dist/
-	@echo "✅ Clean complete"
-
-# Run init command with project name (usage: make run-init PROJECT=my-project)
-run-init: build
-	@if [ -z "$(PROJECT)" ]; then \
-		echo "❌ Error: PROJECT is required"; \
-		echo "Usage: make run-init PROJECT=my-project"; \
-		exit 1; \
-	fi
-	@echo "🚀 Running wisp init $(PROJECT)..."
-	@./wisp init $(PROJECT)
-
-# Run backtest command
-run-backtest: build
-	@echo "🚀 Running wisp backtest..."
-	@./wisp backtest
-
-# Run interactive backtest
-run-interactive: build
-	@echo "🚀 Running wisp backtest --interactive..."
-	@./wisp backtest --interactive
-
-# Run dry-run
-run-dry: build
-	@echo "🚀 Running wisp backtest --dry-run..."
-	@./wisp backtest --dry-run
-
-# Tidy dependencies
-tidy:
-	@echo "📦 Tidying dependencies..."
-	@go mod tidy
-	@echo "✅ Dependencies tidied"
-
-# Format code
-fmt:
-	@echo "🎨 Formatting code..."
-	@go fmt ./...
-	@echo "✅ Code formatted"
-
-# Run linter
-lint:
-	@echo "🔍 Running linter..."
-	@golangci-lint run
-	@echo "✅ Linting complete"
-
-# Show help
 help:
-	@echo "Wisp CLI - Makefile targets:"
-	@echo ""
-	@echo "  build              Build the CLI binary"
-	@echo "  install            Install to \$$GOPATH/bin"
-	@echo "  test               Run tests"
-	@echo "  clean              Clean build artifacts"
-	@echo "  run-init           Run wisp init (usage: make run-init PROJECT=my-project)"
-	@echo "  run-backtest       Run wisp backtest"
-	@echo "  run-interactive    Run wisp backtest --interactive"
-	@echo "  run-dry            Run wisp backtest --dry-run"
-	@echo "  tidy               Tidy go.mod dependencies"
-	@echo "  fmt                Format code"
-	@echo "  lint               Run linter"
-	@echo "  help               Show this help message"
-	@echo ""
+	@echo "Targets: submodules | build | smoke | test"
 
+submodules:
+	git submodule update --init --recursive
+
+build:
+	mkdir -p bin
+	go build -o bin/wisp .
+
+# Compile CLI + reference standalone binary (green packaging path)
+smoke: submodules build
+	cd examples/reference-standalone && go mod tidy && go build -o reference-standalone .
+	@echo ""
+	@echo "OK: bin/wisp and examples/reference-standalone/reference-standalone"
+	@echo "Run (needs wisp.yml with enabled connectors):"
+	@echo "  ./examples/reference-standalone/reference-standalone \\"
+	@echo "    --config ./examples/reference-standalone \\"
+	@echo "    --wisp ./wisp.yml"
+
+test:
+	go test ./internal/services/live/manager/ ./internal/services/compile/ ./sdk/pkg/lifecycle/ ./sdk/pkg/runtime/ -count=1

--- a/examples/reference-standalone/README.md
+++ b/examples/reference-standalone/README.md
@@ -12,24 +12,28 @@ fx.Start → runtime.StartStandalone(strategy, configDir, wispYml) → runtime.W
 - Then performs a single clean `Stop` and the process exits
 - Do **not** write your own signal loop that ignores `/shutdown`
 
-## Run (when connectors build is green)
+## Green path (from monorepo root)
 
 ```bash
-# from monorepo root (wisp + sdk submodule)
-cd examples/reference-standalone
-# copy/adapt config as needed
-go run . -config . -wisp ../../wisp.yml
+# Go 1.26+
+make smoke
+
+# With credentials (copy example and enable an exchange):
+cp wisp.yml.example wisp.yml
+# edit wisp.yml → enable connector + keys
+
+./examples/reference-standalone/reference-standalone \
+  --config ./examples/reference-standalone \
+  --wisp ./wisp.yml
 ```
 
-Until `connectors` hyperliquid is fixed ([connectors#52](https://github.com/wisp-trading/connectors/issues/52)),
-full `go run` may fail to compile the live Module. The source below is still the
-canonical pattern for strategy binaries (including private alpha).
+## TUI / supervisor
 
-## Files
+Place a strategy under `strategies/<name>/` with `main.go` + `config.yml`.  
+`wisp` Start Live will **compile a binary** and spawn it (not a `.so` plugin).
 
-| File | Role |
-|------|------|
-| `main.go` | Process host: fx + StartStandalone + Wait |
-| `strategy.go` | Minimal self-directed strategy |
+Legacy plugin path is only used if no binary can be built.
 
-Private strategies should copy this pattern; they stay out of this repo.
+## Private strategies
+
+Copy this package pattern. Keep private alpha out of product git.

--- a/internal/services/compile/compile.go
+++ b/internal/services/compile/compile.go
@@ -5,139 +5,193 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/wisp-trading/wisp/pkg/strategy"
 )
 
-// compileService handles compilation of strategies into .so plugins
+// compileService builds strategy packages for live execution.
+// Blessed path: standalone binary (main.go present).
+// Legacy: Go plugin .so when only strategy.go exists without main.
 type compileService struct{}
 
 func NewCompileService() strategy.CompileService {
 	return &compileService{}
 }
 
-// CompileStrategy compiles a strategy's .go file into a .so plugin if needed
+// CompileStrategy builds a standalone binary when main.go is present,
+// otherwise falls back to the legacy plugin .so path.
 func (s *compileService) CompileStrategy(strategyPath string) error {
-	strategyName := filepath.Base(strategyPath)
-	strategyGoPath := filepath.Join(strategyPath, "strategy.go")
-	soPath := filepath.Join(strategyPath, strategyName+".so")
+	if isStandalone(strategyPath) {
+		return s.compileBinary(strategyPath)
+	}
+	return s.compilePlugin(strategyPath)
+}
 
-	// Check if strategy.go exists
-	if _, err := os.Stat(strategyGoPath); os.IsNotExist(err) {
-		return fmt.Errorf("strategy.go not found")
+func isStandalone(strategyPath string) bool {
+	_, err := os.Stat(filepath.Join(strategyPath, "main.go"))
+	return err == nil
+}
+
+func binaryPath(strategyPath string) string {
+	return filepath.Join(strategyPath, filepath.Base(strategyPath))
+}
+
+func soPath(strategyPath string) string {
+	name := filepath.Base(strategyPath)
+	return filepath.Join(strategyPath, name+".so")
+}
+
+func compileSourceModTime(strategyPath string) (time.Time, error) {
+	var newest time.Time
+	entries, err := os.ReadDir(strategyPath)
+	if err != nil {
+		return newest, err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if filepath.Ext(name) != ".go" && name != "go.mod" && name != "go.sum" {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().After(newest) {
+			newest = info.ModTime()
+		}
+	}
+	if newest.IsZero() {
+		return newest, fmt.Errorf("no go sources in %s", strategyPath)
+	}
+	return newest, nil
+}
+
+func (s *compileService) compileBinary(strategyPath string) error {
+	name := filepath.Base(strategyPath)
+	out := binaryPath(strategyPath)
+
+	srcTime, err := compileSourceModTime(strategyPath)
+	if err != nil {
+		return err
+	}
+	if info, err := os.Stat(out); err == nil && info.ModTime().After(srcTime) {
+		return nil
 	}
 
-	// Check if .so exists and is up-to-date
+	_ = os.Remove(out)
+
+	fmt.Printf("🔨 Compiling standalone strategy %s...\n", name)
+	fmt.Printf("  📦 go mod tidy...\n")
+	tidyCmd := exec.Command("go", "mod", "tidy")
+	tidyCmd.Dir = strategyPath
+	if outBytes, err := tidyCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("go mod tidy failed: %s", string(outBytes))
+	}
+
+	fmt.Printf("  🔧 go build -o %s .\n", name)
+	cmd := exec.Command("go", "build", "-o", name, ".")
+	cmd.Dir = strategyPath
+	if outBytes, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("standalone build failed: %s", string(outBytes))
+	}
+
+	fmt.Printf("✅ Built standalone binary %s\n\n", out)
+	return nil
+}
+
+// compilePlugin is the legacy .so path (demoted).
+func (s *compileService) compilePlugin(strategyPath string) error {
+	strategyName := filepath.Base(strategyPath)
+	strategyGoPath := filepath.Join(strategyPath, "strategy.go")
+	so := soPath(strategyPath)
+
+	if _, err := os.Stat(strategyGoPath); os.IsNotExist(err) {
+		return fmt.Errorf("strategy.go not found (and no main.go for standalone)")
+	}
+
 	goInfo, err := os.Stat(strategyGoPath)
 	if err != nil {
 		return err
 	}
-
-	soInfo, err := os.Stat(soPath)
-	if err == nil && soInfo.ModTime().After(goInfo.ModTime()) {
-		// .so exists and is newer than .go - no need to rebuild
+	if soInfo, err := os.Stat(so); err == nil && soInfo.ModTime().After(goInfo.ModTime()) {
 		return nil
 	}
 
-	_ = os.Remove(soPath)
+	_ = os.Remove(so)
 
-	// Need to compile
-	fmt.Printf("🔨 Compiling %s strategy...\n", strategyName)
+	fmt.Printf("🔨 Compiling %s strategy (legacy plugin)...\n", strategyName)
+	fmt.Printf("  ⚠️  Plugin packaging is legacy; prefer main.go + StartStandalone + Wait\n")
 
-	// Clear build cache to ensure fresh compilation with current SDK
-	fmt.Printf("  🧹 Clearing build cache...\n")
-	cleanCmd := exec.Command("go", "clean", "-cache")
-	cleanCmd.Dir = strategyPath
-	if err := cleanCmd.Run(); err != nil {
-		// Non-fatal, continue anyway
-		fmt.Printf("  ⚠️  Cache clear warning (continuing): %v\n", err)
-	}
-
-	// First, run go mod tidy to ensure all dependencies are downloaded
-	fmt.Printf("  📦 Downloading dependencies...\n")
 	tidyCmd := exec.Command("go", "mod", "tidy")
 	tidyCmd.Dir = strategyPath
-	tidyOutput, err := tidyCmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to download dependencies: %s", string(tidyOutput))
+	if out, err := tidyCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to download dependencies: %s", string(out))
 	}
 
-	// Now compile the plugin with -a flag (force rebuild all packages)
-	fmt.Printf("  🔧 Building plugin...\n")
-	// Use relative paths since we're setting cmd.Dir to strategyPath
 	outputFileName := strategyName + ".so"
 	cmd := exec.Command("go", "build", "-a", "-buildmode=plugin", "-o", outputFileName, "strategy.go")
 	cmd.Dir = strategyPath
-
-	// Capture both stdout and stderr to show detailed error messages
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		// Return the compilation error with full output
-		return fmt.Errorf("compilation failed: %s", string(output))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("compilation failed: %s", string(out))
 	}
 
 	fmt.Printf("✅ Compiled %s.so successfully\n\n", strategyName)
 	return nil
 }
 
-// PreCompileStrategies scans and compiles all strategies in the strategies directory
-// Returns a map of strategy names to compilation errors (if any)
+// PreCompileStrategies scans and compiles all strategies in the strategies directory.
 func (s *compileService) PreCompileStrategies(strategiesDir string) map[string]error {
 	errors := make(map[string]error)
 
-	// Check if strategies directory exists
 	entries, err := os.ReadDir(strategiesDir)
 	if err != nil {
-		return errors // No strategies directory, return empty map
+		return errors
 	}
 
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
-
-		strategyName := entry.Name()
-		strategyPath := filepath.Join(strategiesDir, strategyName)
+		strategyPath := filepath.Join(strategiesDir, entry.Name())
 		configPath := filepath.Join(strategyPath, "config.yml")
-
-		// Only compile if config.yml exists
 		if _, err := os.Stat(configPath); os.IsNotExist(err) {
 			continue
 		}
-
-		// Try to compile and capture any errors
 		if err := s.CompileStrategy(strategyPath); err != nil {
-			errors[strategyName] = err
+			errors[entry.Name()] = err
 		}
 	}
-
 	return errors
 }
 
-// IsCompiled checks if a strategy has a compiled .so file
+// IsCompiled reports whether a binary or legacy .so is present.
 func (s *compileService) IsCompiled(strategyPath string) bool {
-	strategyName := filepath.Base(strategyPath)
-	soPath := filepath.Join(strategyPath, strategyName+".so")
-	_, err := os.Stat(soPath)
+	if _, err := os.Stat(binaryPath(strategyPath)); err == nil {
+		return true
+	}
+	_, err := os.Stat(soPath(strategyPath))
 	return err == nil
 }
 
-// NeedsRecompile checks if a strategy needs to be recompiled
+// NeedsRecompile reports whether sources are newer than the artifact.
 func (s *compileService) NeedsRecompile(strategyPath string) bool {
-	strategyName := filepath.Base(strategyPath)
-	strategyGoPath := filepath.Join(strategyPath, "strategy.go")
-	soPath := filepath.Join(strategyPath, strategyName+".so")
-
-	goInfo, err := os.Stat(strategyGoPath)
+	srcTime, err := compileSourceModTime(strategyPath)
 	if err != nil {
-		return true // Can't stat .go file, assume needs recompile
+		return true
 	}
-
-	soInfo, err := os.Stat(soPath)
+	var art string
+	if isStandalone(strategyPath) {
+		art = binaryPath(strategyPath)
+	} else {
+		art = soPath(strategyPath)
+	}
+	info, err := os.Stat(art)
 	if err != nil {
-		return true // .so doesn't exist, needs compile
+		return true
 	}
-
-	// Check if .go is newer than .so
-	return goInfo.ModTime().After(soInfo.ModTime())
+	return srcTime.After(info.ModTime())
 }

--- a/internal/services/live/live.go
+++ b/internal/services/live/live.go
@@ -49,7 +49,7 @@ func (s *liveService) ExecuteStrategy(ctx context.Context, strat *config.Strateg
 
 	s.logger.Info("Validated connector configs", "strategy", strat.Name, "connectors", len(connectorConfigs))
 
-	// 2. Compile strategy if needed
+	// 2. Compile strategy (standalone binary preferred when main.go is present)
 	if err := s.compile.CompileStrategy(strat.Path); err != nil {
 		return fmt.Errorf("failed to compile strategy: %w", err)
 	}

--- a/internal/services/live/manager/spawner.go
+++ b/internal/services/live/manager/spawner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
 
 	"github.com/wisp-trading/sdk/pkg/types/config"
@@ -23,24 +24,15 @@ func NewProcessSpawner(logger logging.ApplicationLogger) live.ProcessSpawner {
 	}
 }
 
-// Spawn creates a new wisp run-strategy process
+// Spawn creates a strategy process.
+// Blessed path: run standalone binary built in the strategy directory.
+// Legacy fallback: wisp run-strategy (plugin) when no binary is present.
 func (ps *processSpawner) Spawn(ctx context.Context, strategy *config.Strategy) (*exec.Cmd, error) {
-	// Build command: wisp run-strategy --strategy <name>
-	// The run-strategy command will look in ./strategies/{strategyName}
-	cmd := exec.CommandContext(ctx, "wisp", "run-strategy", "--strategy", strategy.Name)
-
-	// Create new process group (survive parent exit)
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
-	}
-
-	// Create instance log directory
 	instanceLogDir := fmt.Sprintf(".wisp/instances/%s", strategy.Name)
 	if err := os.MkdirAll(instanceLogDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create instance log directory: %w", err)
 	}
 
-	// Redirect stdout/stderr to log files (NOT to TUI)
 	stdoutLog := fmt.Sprintf("%s/stdout.log", instanceLogDir)
 	stderrLog := fmt.Sprintf("%s/stderr.log", instanceLogDir)
 
@@ -48,18 +40,34 @@ func (ps *processSpawner) Spawn(ctx context.Context, strategy *config.Strategy) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to open stdout log: %w", err)
 	}
-
 	stderrFile, err := os.OpenFile(stderrLog, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		_ = stdoutFile.Close()
 		return nil, fmt.Errorf("failed to open stderr log: %w", err)
 	}
 
+	cmd, mode, err := ps.buildCommand(strategy)
+	if err != nil {
+		_ = stdoutFile.Close()
+		_ = stderrFile.Close()
+		return nil, err
+	}
+
+	// Detach from parent process group so the strategy survives TUI exit.
+	// Do not use CommandContext(parent) — parent cancel must not SIGKILL the child;
+	// Stop uses HTTP /shutdown then signals.
+	_ = ctx
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
 	cmd.Stdout = stdoutFile
 	cmd.Stderr = stderrFile
 
 	ps.logger.Info("Spawning strategy process",
 		"strategy", strategy.Name,
+		"mode", mode,
+		"path", cmd.Path,
+		"args", cmd.Args,
 		"stdout_log", stdoutLog,
 		"stderr_log", stderrLog,
 	)
@@ -67,13 +75,63 @@ func (ps *processSpawner) Spawn(ctx context.Context, strategy *config.Strategy) 
 	return cmd, nil
 }
 
+func (ps *processSpawner) buildCommand(strategy *config.Strategy) (*exec.Cmd, string, error) {
+	strategyPath := strategy.Path
+	if strategyPath == "" {
+		strategyPath = filepath.Join("strategies", strategy.Name)
+	}
+
+	bin := filepath.Join(strategyPath, strategy.Name)
+	if abs, err := filepath.Abs(bin); err == nil {
+		bin = abs
+	}
+
+	if st, err := os.Stat(bin); err == nil && !st.IsDir() {
+		// Standalone binary (blessed)
+		configDir := strategyPath
+		if abs, err := filepath.Abs(configDir); err == nil {
+			configDir = abs
+		}
+		settings := resolveSettingsFile()
+		cmd := exec.Command(bin,
+			"--config", configDir,
+			"--wisp", settings,
+		)
+		return cmd, "standalone", nil
+	}
+
+	// Legacy plugin path
+	ps.logger.Warn("No standalone binary found; falling back to legacy plugin run-strategy",
+		"strategy", strategy.Name,
+		"expected_binary", bin,
+	)
+	cmd := exec.Command("wisp", "run-strategy", "--strategy", strategy.Name)
+	return cmd, "plugin-legacy", nil
+}
+
+// resolveSettingsFile prefers wisp.yml, then exchanges.yml, in the process cwd.
+func resolveSettingsFile() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "wisp.yml"
+	}
+	for _, name := range []string{"wisp.yml", "exchanges.yml"} {
+		p := filepath.Join(cwd, name)
+		if _, err := os.Stat(p); err == nil {
+			if abs, err := filepath.Abs(p); err == nil {
+				return abs
+			}
+			return p
+		}
+	}
+	return filepath.Join(cwd, "wisp.yml")
+}
+
 // AttachMonitor starts monitoring process for crashes
 func (ps *processSpawner) AttachMonitor(instance *live.Instance) error {
 	if instance.Cmd == nil {
 		return fmt.Errorf("command not set on instance")
 	}
-
 	ps.logger.Info("Attached monitor to instance", "strategy", instance.StrategyName, "pid", instance.PID)
-
 	return nil
 }

--- a/internal/services/live/manager/spawner_test.go
+++ b/internal/services/live/manager/spawner_test.go
@@ -44,9 +44,10 @@ var _ = Describe("ProcessSpawner", func() {
 		logger = &logging.NoOpLogger{}
 		spawner = manager.NewProcessSpawner(logger)
 
+		// No binary present → legacy plugin spawn path
 		testStrategy = &config.Strategy{
 			Name: "test-momentum",
-			Path: "./strategies/test-momentum",
+			Path: filepath.Join(tmpDir, "strategies", "test-momentum"),
 		}
 
 		ctx, cancel = context.WithCancel(context.Background())
@@ -57,18 +58,33 @@ var _ = Describe("ProcessSpawner", func() {
 	})
 
 	Describe("Spawn", func() {
-		It("should create a command with correct arguments", func() {
+		It("should fall back to legacy run-strategy when no binary exists", func() {
 			cmd, err := spawner.Spawn(ctx, testStrategy)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cmd).NotTo(BeNil())
 
-			// Verify command path and args
-			Expect(cmd.Path).To(ContainSubstring("wisp"))
 			Expect(cmd.Args).To(ContainElements(
-				ContainSubstring("wisp"),
 				"run-strategy",
 				"--strategy",
 				"test-momentum",
+			))
+		})
+
+		It("should spawn standalone binary when present", func() {
+			// Create a fake strategy binary
+			binDir := filepath.Join(tmpDir, "strategies", "test-momentum")
+			Expect(os.MkdirAll(binDir, 0755)).To(Succeed())
+			binPath := filepath.Join(binDir, "test-momentum")
+			Expect(os.WriteFile(binPath, []byte("#!/bin/sh\n"), 0755)).To(Succeed())
+
+			strat := &config.Strategy{Name: "test-momentum", Path: binDir}
+			cmd, err := spawner.Spawn(ctx, strat)
+			Expect(err).NotTo(HaveOccurred())
+			absBin, _ := filepath.Abs(binPath)
+			Expect(cmd.Path).To(Equal(absBin))
+			Expect(cmd.Args).To(ContainElements(
+				"--config",
+				"--wisp",
 			))
 		})
 

--- a/wisp.yml.example
+++ b/wisp.yml.example
@@ -1,0 +1,9 @@
+# Global connector settings for live strategies.
+# Copy to wisp.yml and enable exchanges you use.
+connectors:
+  - name: hyperliquid
+    enabled: false
+    network: mainnet
+    credentials:
+      private_key: ""
+      account_address: ""


### PR DESCRIPTION
## Summary
- TUI/supervisor **Start Live** builds and runs **standalone strategy binaries** when `main.go` is present
- Legacy `run-strategy` / plugins only as fallback
- `make smoke` builds CLI + `examples/reference-standalone`
- Sample configs: `wisp.yml.example`, example `config.yml`

## Test plan
- [x] `go test ./internal/services/live/manager/`
- [x] `go build` CLI + reference-standalone binary
- [ ] Live run with real `wisp.yml` credentials (optional)