### PR TITLE
ci: Go 1.26.5 + golangci-lint v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,21 +12,24 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.24']
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          # Match go.mod / toolchain go1.26.5
+          go-version: '1.26.5'
+          cache-dependency-path: |
+            go.sum
+            sdk/go.sum
 
       - name: Run tests with coverage
-        run: go test -v -coverprofile=coverage.out ./...
+        # CLI packages only — examples/ is a separate module; sdk has its own CI
+        run: go test -v -coverprofile=coverage.out ./cmd/... ./internal/... ./pkg/...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -35,20 +38,26 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           token: ${{ secrets.CODECOV_TOKEN }}
+        continue-on-error: true
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26.5'
+          cache: false
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
-        with:
-          version: latest
-          args: --timeout=5m
+      # Install with the job's Go so the linter binary is built with ≥1.26
+      # (prebuilt v1.x binaries are go1.24 and refuse to target go1.26.5).
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+
+      - name: Run golangci-lint
+        run: golangci-lint run --timeout=5m ./cmd/... ./internal/... ./pkg/...


### PR DESCRIPTION
Fixes Actions failure: golangci-lint go1.24 cannot target go1.26.5. Also checkout submodules.