### PR TITLE
feat: CLI tests + Settings keys via existing field discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
 	github.com/wisp-trading/connectors v0.1.3
-	github.com/wisp-trading/sdk v0.1.3
+	github.com/wisp-trading/sdk v0.1.4
 	go.uber.org/fx v1.24.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/wisp-trading/connectors v0.1.3 h1:IpKaOVaWJGeEjn7ZMxLa/9Ev/J98qC1jM2r2D/JJDZA=
 github.com/wisp-trading/connectors v0.1.3/go.mod h1:XnqwHL/aFdaD52lAbpMk1jiGOi6icMiCSSK+8GqcCaY=
-github.com/wisp-trading/sdk v0.1.3 h1:OPHSmQUWvNZCwECCX2ZLNfzIfmbj116BzXQsSMg5qhs=
-github.com/wisp-trading/sdk v0.1.3/go.mod h1:RzoSgFP8CE4qY7RmDC7pgJu0Zo9J5BvPZQ/+IqX6Jas=
+github.com/wisp-trading/sdk v0.1.4 h1:i/I6t14oqxjSGbYeaJa/8DfN/o+Uq+8Q8puy0WLSbzM=
+github.com/wisp-trading/sdk v0.1.4/go.mod h1:RzoSgFP8CE4qY7RmDC7pgJu0Zo9J5BvPZQ/+IqX6Jas=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=

--- a/internal/handlers/settings/form.go
+++ b/internal/handlers/settings/form.go
@@ -10,6 +10,7 @@ import (
 	"github.com/donderom/bubblon"
 	"github.com/wisp-trading/connectors/pkg/connectors/types"
 	"github.com/wisp-trading/sdk/pkg/types/config"
+	"github.com/wisp-trading/sdk/pkg/types/connector"
 	"github.com/wisp-trading/wisp/internal/router"
 	"github.com/wisp-trading/wisp/internal/ui"
 )
@@ -125,22 +126,26 @@ func (m *ConnectorFormModel) buildForm() *huh.Form {
 		))
 	}
 
-	// Get required credential fields from SDK (e.g., hyperliquid needs "private_key" and "account_address")
+	// Field names from connector NewConfig() via existing GetRequiredCredentialFields.
 	requiredFields := m.connectorSvc.GetRequiredCredentialFields(m.exchangeName)
-	if len(requiredFields) == 0 {
-		// Fallback to common fields if SDK doesn't provide
-		requiredFields = []string{"api_key", "api_secret"}
-	}
 
-	// Add title as a Note field
 	var credFields []huh.Field
-
-	// Title
 	titleEmoji := "➕"
 	titleText := "Add Connector"
 	if m.isEditMode {
 		titleEmoji = "✏️"
 		titleText = "Edit Connector"
+	}
+
+	if len(requiredFields) == 0 {
+		// Do not invent api_key/api_secret — empty means unregistered or no fields.
+		m.credentialPointers = map[string]*string{}
+		credFields = append(credFields,
+			huh.NewNote().
+				Title(fmt.Sprintf("%s  %s", titleEmoji, m.exchangeName)).
+				Description("No credential fields discovered (connector missing or NewConfig empty)."),
+		)
+		return huh.NewForm(huh.NewGroup(credFields...)).WithTheme(huh.ThemeCharm())
 	}
 
 	credFields = append(credFields,
@@ -356,11 +361,19 @@ func (m *ConnectorFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *ConnectorFormModel) saveConnector() error {
-	// Validate credentials are not empty
-	for key, value := range m.connector.Credentials {
-		if strings.TrimSpace(value) == "" {
+	// Required keys from the same discovery path as the form.
+	for _, key := range m.connectorSvc.GetRequiredCredentialFields(m.connector.Name) {
+		if strings.TrimSpace(m.connector.Credentials[key]) == "" {
 			return fmt.Errorf("credential '%s' cannot be empty", formatFieldName(key))
 		}
+	}
+
+	// Full connector validation (MapToSDKConfig + Config.Validate).
+	if err := m.connectorSvc.ValidateConnectorConfig(
+		connector.ExchangeName(m.connector.Name),
+		m.connector,
+	); err != nil {
+		return err
 	}
 
 	if m.isEditMode {
@@ -441,11 +454,8 @@ func (m *ConnectorFormModel) renderDetailView() string {
 	details.WriteString(ui.SectionHeaderStyle.Render("Credentials"))
 	details.WriteString("\n\n")
 
-	// Get required fields from SDK for this exchange
+	// Same discovery path as the edit form (NewConfig JSON keys).
 	requiredFields := m.connectorSvc.GetRequiredCredentialFields(m.connector.Name)
-	if len(requiredFields) == 0 {
-		requiredFields = []string{"api_key", "api_secret"}
-	}
 
 	// Show each credential field dynamically
 	for _, fieldName := range requiredFields {

--- a/internal/handlers/settings/save_test.go
+++ b/internal/handlers/settings/save_test.go
@@ -28,8 +28,8 @@ func (s *stubConfig) UpdateConnector(c config.Connector) error {
 	s.updated = &c
 	return nil
 }
-func (s *stubConfig) RemoveConnector(string) error           { return nil }
-func (s *stubConfig) EnableConnector(string, bool) error     { return nil }
+func (s *stubConfig) RemoveConnector(string) error       { return nil }
+func (s *stubConfig) EnableConnector(string, bool) error { return nil }
 
 type stubConnectorSvc struct {
 	fields []string

--- a/internal/handlers/settings/save_test.go
+++ b/internal/handlers/settings/save_test.go
@@ -1,0 +1,114 @@
+package settings
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/wisp-trading/sdk/pkg/types/config"
+	"github.com/wisp-trading/sdk/pkg/types/connector"
+)
+
+// stubConfig is a minimal Configuration for save tests.
+type stubConfig struct {
+	added   *config.Connector
+	updated *config.Connector
+}
+
+func (s *stubConfig) LoadSettings(string) (*config.Settings, error) { return &config.Settings{}, nil }
+func (s *stubConfig) GetConnectors() ([]config.Connector, error)    { return nil, nil }
+func (s *stubConfig) GetEnabledConnectors() ([]config.Connector, error) {
+	return nil, nil
+}
+func (s *stubConfig) SaveSettings(*config.Settings) error { return nil }
+func (s *stubConfig) AddConnector(c config.Connector) error {
+	s.added = &c
+	return nil
+}
+func (s *stubConfig) UpdateConnector(c config.Connector) error {
+	s.updated = &c
+	return nil
+}
+func (s *stubConfig) RemoveConnector(string) error           { return nil }
+func (s *stubConfig) EnableConnector(string, bool) error     { return nil }
+
+type stubConnectorSvc struct {
+	fields []string
+	valid  error
+}
+
+func (s *stubConnectorSvc) GetMatchingConnectors() (map[connector.ExchangeName]config.Connector, error) {
+	return nil, nil
+}
+func (s *stubConnectorSvc) ValidateConnectorConfig(connector.ExchangeName, config.Connector) error {
+	return s.valid
+}
+func (s *stubConnectorSvc) MapToSDKConfig(config.Connector) (connector.Config, error) {
+	return nil, nil
+}
+func (s *stubConnectorSvc) GetConnectorConfigsForStrategy([]string) (map[connector.ExchangeName]connector.Config, error) {
+	return nil, nil
+}
+func (s *stubConnectorSvc) GetRequiredCredentialFields(string) []string { return s.fields }
+
+func TestSaveConnector_RequiresDiscoveredFields(t *testing.T) {
+	cfg := &stubConfig{}
+	svc := &stubConnectorSvc{fields: []string{"private_key", "account_address"}}
+	m := &ConnectorFormModel{
+		config:       cfg,
+		connectorSvc: svc,
+		connector: config.Connector{
+			Name:        "hyperliquid",
+			Enabled:     true,
+			Credentials: map[string]string{"private_key": "x"}, // missing account_address
+		},
+	}
+	err := m.saveConnector()
+	if err == nil {
+		t.Fatal("expected missing field error")
+	}
+}
+
+func TestSaveConnector_RunsValidate(t *testing.T) {
+	cfg := &stubConfig{}
+	svc := &stubConnectorSvc{
+		fields: []string{"api_key", "api_secret"},
+		valid:  fmt.Errorf("sdk says no"),
+	}
+	m := &ConnectorFormModel{
+		config:       cfg,
+		connectorSvc: svc,
+		connector: config.Connector{
+			Name:    "bybit",
+			Enabled: true,
+			Credentials: map[string]string{
+				"api_key":    "k",
+				"api_secret": "s",
+			},
+		},
+	}
+	err := m.saveConnector()
+	if err == nil || err.Error() != "sdk says no" {
+		t.Fatalf("expected validate error, got %v", err)
+	}
+}
+
+func TestSaveConnector_SuccessAdd(t *testing.T) {
+	cfg := &stubConfig{}
+	svc := &stubConnectorSvc{fields: []string{"api_key"}}
+	m := &ConnectorFormModel{
+		config:       cfg,
+		connectorSvc: svc,
+		isEditMode:   false,
+		connector: config.Connector{
+			Name:        "bybit",
+			Enabled:     true,
+			Credentials: map[string]string{"api_key": "k"},
+		},
+	}
+	if err := m.saveConnector(); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.added == nil || cfg.added.Name != "bybit" {
+		t.Fatalf("not added: %+v", cfg.added)
+	}
+}

--- a/internal/services/compile/compile_test.go
+++ b/internal/services/compile/compile_test.go
@@ -1,0 +1,70 @@
+package compile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCompileStrategyRequiresMainGo(t *testing.T) {
+	dir := t.TempDir()
+	// strategy.go only — no main.go
+	if err := os.WriteFile(filepath.Join(dir, "strategy.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewCompileService()
+	err := svc.CompileStrategy(dir)
+	if err == nil {
+		t.Fatal("expected error without main.go")
+	}
+	if !contains(err.Error(), "main.go") {
+		t.Fatalf("error should mention main.go: %v", err)
+	}
+}
+
+func TestIsCompiledAndNeedsRecompile(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Base(dir)
+	// no binary
+	svc := NewCompileService()
+	if svc.IsCompiled(dir) {
+		t.Fatal("expected not compiled")
+	}
+	if !svc.NeedsRecompile(dir) {
+		t.Fatal("expected needs recompile without sources/binary")
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module t\n\ngo 1.22\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// still no binary
+	if !svc.NeedsRecompile(dir) {
+		t.Fatal("expected needs recompile when binary missing")
+	}
+
+	// touch a stub binary newer than sources — skip real go build
+	bin := filepath.Join(dir, name)
+	if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// binary mtime may equal source on fast FS; force NeedsRecompile path via older binary
+	// IsCompiled should be true
+	if !svc.IsCompiled(dir) {
+		t.Fatal("expected compiled when binary present")
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		(len(s) > 0 && (func() bool {
+			for i := 0; i+len(sub) <= len(s); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		})()))
+}


### PR DESCRIPTION
## Summary
- **#35** Settings: discover fields only via \`GetRequiredCredentialFields\`; validate-on-save with \`ValidateConnectorConfig\`
- **#34** Tests: compile, form save, (sdk covers settings home + field discovery)
- sdk **v0.1.4** (hardened discovery, no new schema types)

## Test plan
- [x] \`go test ./internal/handlers/settings/ ./internal/services/compile/\`
- [ ] CI green