### PR TITLE
feat(cli): simple setup, keys, start/stop/monitor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
 	github.com/wisp-trading/connectors v0.1.3
-	github.com/wisp-trading/sdk v0.1.4
+	github.com/wisp-trading/sdk v0.1.5
 	go.uber.org/fx v1.24.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/wisp-trading/connectors v0.1.3 h1:IpKaOVaWJGeEjn7ZMxLa/9Ev/J98qC1jM2r2D/JJDZA=
 github.com/wisp-trading/connectors v0.1.3/go.mod h1:XnqwHL/aFdaD52lAbpMk1jiGOi6icMiCSSK+8GqcCaY=
-github.com/wisp-trading/sdk v0.1.4 h1:i/I6t14oqxjSGbYeaJa/8DfN/o+Uq+8Q8puy0WLSbzM=
-github.com/wisp-trading/sdk v0.1.4/go.mod h1:RzoSgFP8CE4qY7RmDC7pgJu0Zo9J5BvPZQ/+IqX6Jas=
+github.com/wisp-trading/sdk v0.1.5 h1:ye4MLZJ31SuHfjC0gzIl2YqwugcaR77dSZhnDbNKI1k=
+github.com/wisp-trading/sdk v0.1.5/go.mod h1:RzoSgFP8CE4qY7RmDC7pgJu0Zo9J5BvPZQ/+IqX6Jas=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=

--- a/internal/handlers/help.go
+++ b/internal/handlers/help.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wisp-trading/wisp/internal/router"
+	"github.com/wisp-trading/wisp/internal/ui"
+)
+
+// helpModel is a short in-app guide for the three core flows.
+type helpModel struct {
+	router router.Router
+}
+
+func NewHelpView(r router.Router) tea.Model {
+	return &helpModel{router: r}
+}
+
+func (m *helpModel) Init() tea.Cmd { return nil }
+
+func (m *helpModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "esc", "enter", "ctrl+c":
+			return m, m.router.Back()
+		}
+	}
+	return m, nil
+}
+
+func (m *helpModel) View() string {
+	title := ui.TitleStyle.Render("ℹ️  How to use Wisp")
+	body := ui.ItemStyle.Render(`
+Three things this CLI is for:
+
+1. New project
+   Menu → Create New Project
+   Or:  wisp init my-bot
+   Creates strategies/<name>/ with main.go (StartStandalone + Wait).
+   No API keys in the project.
+
+2. Exchange keys
+   Menu → Settings
+   Add Hyperliquid / Polymarket / … credentials.
+   Saved to ~/.wisp/connectors.yml (shared by every strategy).
+
+3. Live trading
+   Menu → Strategies → open a strategy → Start Live
+   Compiles the binary and runs it.
+   Menu → Monitor → select instance → Stop (HTTP shutdown, then force if needed).
+
+Tips
+  • Strategy config.yml only lists exchanges/assets — never secrets.
+  • Prefer Hyperliquid perps for production; other venues are beta/experimental.
+  • q goes back; Ctrl+C quits the app from the main menu.
+`)
+	help := ui.MutedStyle.Render("↵ / q  Back")
+	return ui.MenuBoxStyle.Width(72).Render("\n" + title + "\n" + body + "\n" + help + "\n")
+}

--- a/internal/handlers/menu.go
+++ b/internal/handlers/menu.go
@@ -2,15 +2,18 @@ package handlers
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/donderom/bubblon"
 	"github.com/wisp-trading/wisp/internal/router"
+	"github.com/wisp-trading/wisp/internal/setup/types"
 	"github.com/wisp-trading/wisp/internal/ui"
 )
 
 // mainMenuModel represents the main menu TUI
 type mainMenuModel struct {
-	choices []string
-	cursor  int
-	router  router.Router
+	choices  []string
+	cursor   int
+	router   router.Router
+	scaffold types.ScaffoldService
 }
 
 func (m mainMenuModel) Init() tea.Cmd {
@@ -32,23 +35,17 @@ func (m mainMenuModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.cursor++
 			}
 		case "enter":
-			// Navigate using the router instead of quitting
 			switch m.choices[m.cursor] {
 			case "Strategies":
-				return m, func() tea.Msg {
-					return router.NavigateMsg{Route: router.RouteStrategyList}
-				}
+				return m, m.router.NavigateTo(router.RouteStrategyList)
 			case "Monitor":
-				return m, func() tea.Msg {
-					return router.NavigateMsg{Route: router.RouteMonitor}
-				}
+				return m, m.router.NavigateTo(router.RouteMonitor)
 			case "Settings":
-				return m, func() tea.Msg {
-					return router.NavigateMsg{Route: router.RouteSettingsList}
-				}
-			case "Help", "Create New Project":
-				// TODO: Register these routes when implemented
-				return m, nil
+				return m, m.router.NavigateTo(router.RouteSettingsList)
+			case "Create New Project":
+				return m, bubblon.Open(NewProjectCreateView(m.router, m.scaffold))
+			case "Help":
+				return m, bubblon.Open(NewHelpView(m.router))
 			}
 		}
 	}
@@ -56,13 +53,13 @@ func (m mainMenuModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m mainMenuModel) View() string {
-	title := ui.TitleCenteredStyle.Render("WISP CLI v0.1.0")
+	title := ui.TitleCenteredStyle.Render("WISP")
 
 	var s string
 	s += "\n" + title + "\n\n"
-	s += ui.MutedStyle.Render("What would you like to do?") + "\n\n"
+	s += ui.MutedStyle.Render("Project · Keys · Live strategies") + "\n\n"
 
-	icons := []string{"📂", "📊", "⚙️", "ℹ️", "🆕"}
+	icons := []string{"📂", "📊", "⚙️", "🆕", "ℹ️"}
 
 	for i, choice := range m.choices {
 		cursor := "  "
@@ -74,7 +71,7 @@ func (m mainMenuModel) View() string {
 		}
 	}
 
-	s += "\n" + ui.MutedStyle.Render("↑↓/jk Navigate  ↵ Select  q Quit")
+	s += "\n" + ui.MutedStyle.Render("↑↓ Navigate  ↵ Select  q Quit")
 
 	return ui.MenuBoxStyle.Render(s)
 }

--- a/internal/handlers/project_create.go
+++ b/internal/handlers/project_create.go
@@ -1,0 +1,95 @@
+package handlers
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wisp-trading/wisp/internal/router"
+	"github.com/wisp-trading/wisp/internal/setup/types"
+	"github.com/wisp-trading/wisp/internal/ui"
+)
+
+// projectCreateModel is a small in-router flow: name → scaffold starter strategy.
+type projectCreateModel struct {
+	router   router.Router
+	scaffold types.ScaffoldService
+	name     string
+	err      error
+	done     bool
+	doneMsg  string
+}
+
+func NewProjectCreateView(r router.Router, scaffold types.ScaffoldService) tea.Model {
+	return &projectCreateModel{router: r, scaffold: scaffold}
+}
+
+func (m *projectCreateModel) Init() tea.Cmd { return nil }
+
+func (m *projectCreateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if m.done {
+			switch msg.String() {
+			case "q", "esc", "enter", "ctrl+c":
+				return m, m.router.Back()
+			}
+			return m, nil
+		}
+		switch msg.String() {
+		case "ctrl+c":
+			return m, tea.Quit
+		case "esc", "q":
+			return m, m.router.Back()
+		case "enter":
+			name := strings.TrimSpace(strings.ReplaceAll(m.name, " ", "_"))
+			if name == "" {
+				m.err = fmt.Errorf("project name cannot be empty")
+				return m, nil
+			}
+			if err := m.scaffold.CreateProject(name); err != nil {
+				m.err = err
+				return m, nil
+			}
+			m.done = true
+			m.err = nil
+			m.doneMsg = fmt.Sprintf("Created ./%s\n\nNext: Settings → add keys, then Strategies → Start Live\nor: cd %s/strategies/starter && go mod tidy && go run .", name, name)
+			return m, nil
+		case "backspace":
+			if len(m.name) > 0 {
+				m.name = m.name[:len(m.name)-1]
+			}
+			m.err = nil
+		default:
+			if len(msg.String()) == 1 {
+				c := msg.String()[0]
+				if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+					(c >= '0' && c <= '9') || c == '_' || c == '-' || c == ' ' {
+					m.name += msg.String()
+					m.err = nil
+				}
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m *projectCreateModel) View() string {
+	title := ui.TitleStyle.Render("🆕  Create New Project")
+	if m.done {
+		body := ui.StatusReadyStyle.Render("✓ "+m.doneMsg) + "\n\n" +
+			ui.MutedStyle.Render("↵ / q  Back to menu")
+		return ui.MenuBoxStyle.Width(72).Render("\n" + title + "\n\n" + body + "\n")
+	}
+
+	var s string
+	s += "\n" + title + "\n\n"
+	s += ui.MutedStyle.Render("Creates strategies/starter/ with main.go (standalone).") + "\n"
+	s += ui.MutedStyle.Render("Keys stay in Settings (~/.wisp/connectors.yml) — not in the project.") + "\n\n"
+	s += ui.LabelStyle.Width(0).Render("Project name: ") + ui.InputStyle.Render(m.name+"_") + "\n\n"
+	if m.err != nil {
+		s += ui.ErrorBoxStyle.Width(0).Render("✗ "+m.err.Error()) + "\n\n"
+	}
+	s += ui.MutedStyle.Render("↵ Create   q Back")
+	return ui.MenuBoxStyle.Width(72).Render(s)
+}

--- a/internal/handlers/root.go
+++ b/internal/handlers/root.go
@@ -16,10 +16,10 @@ type RootHandler interface {
 	Handle(cmd *cobra.Command, args []string) error
 }
 
-// RootHandler handles the root command and main menu
 type rootHandler struct {
 	strategyBrowser      strategies.StrategyBrowser
 	initHandler          setup.InitHandler
+	scaffold             setup.ScaffoldService
 	backtestHandler      backtesting.BacktestHandler
 	analyzeHandler       backtesting.AnalyzeHandler
 	monitorViewFactory   monitor.MonitorViewFactory
@@ -33,6 +33,7 @@ type rootHandler struct {
 func NewRootHandler(
 	strategyBrowser strategies.StrategyBrowser,
 	initHandler setup.InitHandler,
+	scaffold setup.ScaffoldService,
 	backtestHandler backtesting.BacktestHandler,
 	analyzeHandler backtesting.AnalyzeHandler,
 	monitorViewFactory monitor.MonitorViewFactory,
@@ -42,7 +43,6 @@ func NewRootHandler(
 	deleteConfirmFactory settings.DeleteConfirmViewFactory,
 	r router.Router,
 ) RootHandler {
-	// Register ALL routes with the router at initialization
 	r.RegisterRoute(router.RouteMonitor, func() tea.Model {
 		return monitorViewFactory()
 	})
@@ -70,6 +70,7 @@ func NewRootHandler(
 	return &rootHandler{
 		strategyBrowser:      strategyBrowser,
 		initHandler:          initHandler,
+		scaffold:             scaffold,
 		backtestHandler:      backtestHandler,
 		analyzeHandler:       analyzeHandler,
 		monitorViewFactory:   monitorViewFactory,
@@ -82,32 +83,27 @@ func NewRootHandler(
 }
 
 func (h *rootHandler) Handle(cmd *cobra.Command, args []string) error {
-
 	cliMode, _ := cmd.Flags().GetBool("cli")
-
 	if cliMode || len(args) > 0 {
 		return cmd.Help()
 	}
-
-	return h.runMainMenu(cmd)
+	return h.runMainMenu()
 }
 
-func (h *rootHandler) runMainMenu(_ *cobra.Command) error {
+func (h *rootHandler) runMainMenu() error {
 	m := mainMenuModel{
 		choices: []string{
 			"Strategies",
 			"Monitor",
 			"Settings",
-			"Help",
 			"Create New Project",
+			"Help",
 		},
-		router: h.router,
+		router:   h.router,
+		scaffold: h.scaffold,
 	}
 
-	// Set main menu as the initial view in router
 	h.router.SetInitialView(m)
-
-	// Run the router ONCE - all navigation happens within this single program
 	p := tea.NewProgram(h.router, tea.WithAltScreen())
 	_, err := p.Run()
 	return err

--- a/internal/handlers/settings/list.go
+++ b/internal/handlers/settings/list.go
@@ -48,28 +48,32 @@ func NewSettingsListView(
 }
 
 func (m *ConnectorListModel) Init() tea.Cmd {
-	// Load configured connectors
+	m.err = nil
 	connectorList, err := m.config.GetConnectors()
 	if err != nil {
+		// Still show available exchanges so user can add the first key.
 		m.err = err
-		return nil
+		m.configured = []config.Connector{}
+	} else {
+		m.configured = connectorList
 	}
-	m.configured = connectorList
 
-	// Get available connectors from SDK
-	allAvailable := types.AllConnectors
-
-	// Filter out already configured ones
 	configuredMap := make(map[string]bool)
 	for _, c := range m.configured {
 		configuredMap[c.Name] = true
 	}
 
 	m.available = []string{}
-	for _, name := range allAvailable {
+	for _, name := range types.AllConnectors {
 		if !configuredMap[string(name)] {
 			m.available = append(m.available, string(name))
 		}
+	}
+
+	// First run: jump cursor to "add" section when nothing configured.
+	if len(m.configured) == 0 && len(m.available) > 0 {
+		m.cursor = 0
+		m.inAvailableSection = true
 	}
 
 	return nil
@@ -138,35 +142,34 @@ func (m *ConnectorListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *ConnectorListModel) View() string {
 	var content strings.Builder
 
-	// Title
-	title := ui.TitleStyle.Render("⚙️  Connector Configuration")
+	title := ui.TitleStyle.Render("⚙️  Exchange keys")
 	content.WriteString(title)
+	content.WriteString("\n")
+	content.WriteString(ui.MutedStyle.Render("Stored in ~/.wisp/connectors.yml — shared by all strategies"))
 	content.WriteString("\n\n")
 
-	// Error message if any
 	if m.err != nil {
-		errorBox := ui.ErrorBoxStyle.
-			Width(68).
-			Render("❌ " + m.err.Error())
+		errorBox := ui.ErrorBoxStyle.Width(68).Render("❌ " + m.err.Error())
 		content.WriteString(errorBox)
 		content.WriteString("\n\n")
 	}
 
-	// Success message if any
 	if m.successMsg != "" {
-		successMsg := ui.StatusReadyStyle.Render("✓ " + m.successMsg)
-		content.WriteString(successMsg)
+		content.WriteString(ui.StatusReadyStyle.Render("✓ " + m.successMsg))
 		content.WriteString("\n\n")
 	}
 
-	// Section 1: Configured Connectors
-	sectionHeader := ui.SectionHeaderStyle.Render("📋 CONFIGURED CONNECTORS")
+	if len(m.configured) == 0 && m.err == nil {
+		content.WriteString(ui.MutedStyle.Render("No keys yet. Select an exchange below and press Enter."))
+		content.WriteString("\n\n")
+	}
+
+	sectionHeader := ui.SectionHeaderStyle.Render("📋 CONFIGURED")
 	content.WriteString(sectionHeader)
 	content.WriteString("\n\n")
 
 	if len(m.configured) == 0 {
-		emptyMsg := ui.MutedStyle.Render("   No connectors configured yet")
-		content.WriteString(emptyMsg)
+		content.WriteString(ui.MutedStyle.Render("   (none)"))
 		content.WriteString("\n")
 	} else {
 		for i, conn := range m.configured {

--- a/internal/handlers/strategies/browse/list.go
+++ b/internal/handlers/strategies/browse/list.go
@@ -77,7 +77,12 @@ func (m *strategyListView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *strategyListView) View() string {
 	if len(m.strategies) == 0 {
-		return ui.TitleStyle.Render("STRATEGIES") + "\n\n" + ui.SubtitleStyle.Render("No strategies found. Create a new one to get started.")
+		return ui.TitleStyle.Render("STRATEGIES") + "\n\n" +
+			ui.SubtitleStyle.Render("No strategies in ./strategies.") + "\n\n" +
+			ui.MutedStyle.Render("Create New Project from the menu, or:") + "\n" +
+			ui.MutedStyle.Render("  wisp init my-bot") + "\n\n" +
+			ui.MutedStyle.Render("Then: Settings → keys · here → Start Live · Monitor → Stop") + "\n\n" +
+			ui.MutedStyle.Render("q Back")
 	}
 
 	var content string

--- a/internal/setup/handlers/init_tui.go
+++ b/internal/setup/handlers/init_tui.go
@@ -251,15 +251,15 @@ func fetchFromSDK() ([]StrategyTemplate, error) {
 	return templates, nil
 }
 
-// getFallbackStrategies returns a hardcoded list of strategies as fallback
+// getFallbackStrategies returns local templates (no remote clone).
 func getFallbackStrategies() []StrategyTemplate {
 	return []StrategyTemplate{
 		{
-			Name:        "mean_reversion",
-			DisplayName: "Mean Reversion Strategy",
-			Description: "Bollinger Bands mean reversion with RSI confirmation",
-			Icon:        "📉",
-			SDKExample:  "mean_reversion",
+			Name:        "starter",
+			DisplayName: "Starter (standalone)",
+			Description: "main.go + StartStandalone + Wait — keys via Settings",
+			Icon:        "🚀",
+			SDKExample:  "starter",
 		},
 	}
 }

--- a/internal/setup/services/scaffold.go
+++ b/internal/setup/services/scaffold.go
@@ -3,52 +3,61 @@ package services
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/afero"
 	"github.com/wisp-trading/wisp/internal/setup/types"
 )
 
-// scaffoldService handles project creation and scaffolding
+// scaffolder creates a minimal local project: strategies/<name>/ with main.go + config.yml.
+// Credentials are never written here — use wisp TUI Settings → ~/.wisp/connectors.yml.
 type scaffolder struct {
 	fs afero.Fs
 }
 
 func NewScaffoldService() types.ScaffoldService {
-	return &scaffolder{
-		fs: afero.NewOsFs(),
-	}
+	return &scaffolder{fs: afero.NewOsFs()}
 }
 
-type ProjectData struct {
-	ProjectName     string
-	ModulePath      string
-	StrategyPackage string
-}
-
+// CreateProject scaffolds a starter strategy project under the given directory name.
 func (s *scaffolder) CreateProject(name string) error {
-	return s.CreateProjectWithStrategy(name, "mean_reversion")
+	return s.CreateProjectWithStrategy(name, "starter")
 }
 
+// CreateProjectWithStrategy creates the project. strategyExample is the strategy folder name
+// (defaults to "starter" when empty).
 func (s *scaffolder) CreateProjectWithStrategy(name, strategyExample string) error {
-	green := color.New(color.FgGreen, color.Bold)
-	fmt.Printf("🚀 Creating Wisp project: %s\n\n", green.Sprint(name))
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("project name cannot be empty")
+	}
+	if strategyExample == "" {
+		strategyExample = "starter"
+	}
+	// Sanitize strategy folder
+	strategyExample = strings.ReplaceAll(strategyExample, " ", "_")
 
-	// Check if exists
+	green := color.New(color.FgGreen, color.Bold)
+	fmt.Printf("Creating Wisp project: %s\n\n", green.Sprint(name))
+
 	if exists, _ := afero.DirExists(s.fs, name); exists {
 		return fmt.Errorf("directory '%s' already exists", name)
 	}
 
-	data := ProjectData{
-		ProjectName:     name,
-		ModulePath:      "github.com/your-username/" + name,
-		StrategyPackage: strategyExample,
+	strategyDir := filepath.Join(name, "strategies", strategyExample)
+	if err := os.MkdirAll(strategyDir, 0o755); err != nil {
+		return fmt.Errorf("create strategy dir: %w", err)
 	}
 
-	// Generate files (git clone will create the directory)
-	if err := s.generateFiles(name, strategyExample, data); err != nil {
+	if err := s.writeStrategyFiles(name, strategyExample, strategyDir); err != nil {
+		_ = os.RemoveAll(name)
+		return err
+	}
+
+	if err := s.writeProjectRoot(name, strategyExample); err != nil {
+		_ = os.RemoveAll(name)
 		return err
 	}
 
@@ -56,199 +65,202 @@ func (s *scaffolder) CreateProjectWithStrategy(name, strategyExample string) err
 	return nil
 }
 
-func (s *scaffolder) generateFiles(name, strategyExample string, data ProjectData) error {
-	// Git clone with sparse checkout directly to project directory
-	fmt.Printf("  📦 Downloading %s example from GitHub...\n", strategyExample)
+func (s *scaffolder) writeStrategyFiles(project, strategy, strategyDir string) error {
+	module := "github.com/example/" + project + "/strategies/" + strategy
 
-	cmd := exec.Command("git", "clone", "--depth", "1", "--filter=blob:none", "--sparse",
-		"https://github.com/wisp-trading/sdk.git", name)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to clone SDK: %w", err)
-	}
+	files := map[string]string{
+		"go.mod": fmt.Sprintf(`module %s
 
-	// Set sparse checkout to get ONLY the selected example
-	examplePath := fmt.Sprintf("examples/%s", strategyExample)
-	cmd = exec.Command("git", "-C", name, "sparse-checkout", "set", examplePath)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to checkout %s: %w", strategyExample, err)
-	}
+go 1.26
 
-	// Create strategies directory in project root
-	strategiesDir := filepath.Join(name, "strategies")
-	if err := os.MkdirAll(strategiesDir, 0755); err != nil {
-		return fmt.Errorf("failed to create strategies directory: %w", err)
-	}
-
-	// Create strategy subdirectory (strategies/{strategy_name}/)
-	strategyDestDir := filepath.Join(strategiesDir, strategyExample)
-	if err := os.MkdirAll(strategyDestDir, 0755); err != nil {
-		return fmt.Errorf("failed to create strategy subdirectory: %w", err)
-	}
-
-	// Move everything from examples/{strategy} to strategies/{strategy_name}/
-	strategySourceDir := filepath.Join(name, "examples", strategyExample)
-	files, err := os.ReadDir(strategySourceDir)
-	if err != nil {
-		return fmt.Errorf("failed to read %s directory: %w", strategyExample, err)
-	}
-
-	for _, file := range files {
-		srcPath := filepath.Join(strategySourceDir, file.Name())
-		dstPath := filepath.Join(strategyDestDir, file.Name())
-
-		if err := os.Rename(srcPath, dstPath); err != nil {
-			return fmt.Errorf("failed to move %s: %w", file.Name(), err)
-		}
-		fmt.Printf("  📝 strategies/%s/%s\n", strategyExample, file.Name())
-	}
-
-	// Remove examples directory
-	if err := os.RemoveAll(filepath.Join(name, "examples")); err != nil {
-		return fmt.Errorf("failed to remove examples directory: %w", err)
-	}
-
-	// Remove .git directory
-	if err := os.RemoveAll(filepath.Join(name, ".git")); err != nil {
-		return fmt.Errorf("failed to remove .git directory: %w", err)
-	}
-
-	// Generate root-level files (go.mod, README.md)
-	if err := s.generateRootFiles(name, strategyExample, data); err != nil {
-		return fmt.Errorf("failed to generate root files: %w", err)
-	}
-
-	// Generate configuration files
-	if err := s.generateConfigFiles(name, strategyExample); err != nil {
-		return fmt.Errorf("failed to generate config files: %w", err)
-	}
-
-	return nil
-}
-
-func (s *scaffolder) generateRootFiles(name, strategyExample string, data ProjectData) error {
-	// Generate go.mod
-	goModContent := fmt.Sprintf(`module %s
-
-go 1.23
-
-require github.com/wisp-trading/sdk v0.0.0
-`, data.ModulePath)
-
-	goModPath := filepath.Join(name, "go.mod")
-	if err := os.WriteFile(goModPath, []byte(goModContent), 0644); err != nil {
-		return fmt.Errorf("failed to write go.mod: %w", err)
-	}
-	fmt.Printf("  📝 go.mod\n")
-
-	// Generate README.md
-	readmeContent := fmt.Sprintf(`# %s
-
-A Wisp trading strategy project using the %s strategy.
-
-## Setup
-
-1. Configure your exchange credentials in `+"`exchanges.yml`"+`
-2. Install dependencies: `+"`go mod tidy`"+`
-3. Run the strategy: `+"`go run strategies/%s/strategy.go`"+`
-
-## Configuration
-
-- `+"`exchanges.yml`"+` - Global exchange and asset configuration
-- `+"`strategies/%s/config.yml`"+` - Strategy-specific parameters
-
-## Documentation
-
-For more information, visit: https://github.com/wisp-trading/sdk
-`, name, strategyExample, strategyExample, strategyExample)
-
-	readmePath := filepath.Join(name, "README.md")
-	if err := os.WriteFile(readmePath, []byte(readmeContent), 0644); err != nil {
-		return fmt.Errorf("failed to write README.md: %w", err)
-	}
-	fmt.Printf("  📝 README.md\n")
-
-	return nil
-}
-
-func (s *scaffolder) generateConfigFiles(name, strategyExample string) error {
-	// Note: config.yml comes from the SDK example and contains only metadata
-	// We do NOT generate it here - it's downloaded with the strategy
-
-	// Generate exchanges.yml with assets configuration
-	exchangesYAML := `# Global Exchange Configuration
-# Configure which exchanges and assets to trade
-
+require (
+	github.com/wisp-trading/connectors v0.1.3
+	github.com/wisp-trading/sdk v0.1.4
+	go.uber.org/fx v1.24.0
+)
+`, module),
+		"config.yml": fmt.Sprintf(`name: %s
+description: Starter strategy (standalone binary)
 exchanges:
-  - name: binance
-    enabled: true
-    credentials:
-      api_key: ""
-      api_secret: ""
-    assets:
-      - BTC/USDT
-      - ETH/USDT
+  - hyperliquid
+assets:
+  hyperliquid:
+    - base: BTC
+      quote: USD
+      instruments: [perp]
+parameters:
+  dry_run: true
+`, strategy),
+		"main.go": `package main
 
-  - name: bybit
-    enabled: true
-    credentials:
-      api_key: ""
-      api_secret: ""
-    assets:
-      - BTC/USDT
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
 
-  - name: paradex
-    enabled: false
-    credentials:
-      account_address: ""
-      eth_private_key: ""
-    assets:
-      - BTC/USD
-`
+	"github.com/wisp-trading/connectors/pkg/connectors"
+	"github.com/wisp-trading/sdk/pkg/types/runtime"
+	"github.com/wisp-trading/sdk/pkg/types/strategy"
+	"github.com/wisp-trading/sdk/wisp"
+	"go.uber.org/fx"
+)
 
-	exchangesPath := filepath.Join(name, "exchanges.yml")
-	if err := os.WriteFile(exchangesPath, []byte(exchangesYAML), 0644); err != nil {
-		return fmt.Errorf("failed to write exchanges.yml: %w", err)
+func main() {
+	configDir := flag.String("config", ".", "strategy config directory")
+	// Empty --wisp → ~/.wisp/connectors.yml (set keys via: wisp → Settings)
+	wispPath := flag.String("wisp", "", "connector settings path (default: ~/.wisp/connectors.yml)")
+	flag.Parse()
+
+	ctx := context.Background()
+	var (
+		rt    runtime.Runtime
+		strat strategy.Strategy
+	)
+
+	app := fx.New(
+		connectors.Module,
+		wisp.Module,
+		fx.Provide(NewStrategy),
+		fx.Populate(&rt, &strat),
+		fx.NopLogger,
+	)
+
+	if err := app.Start(ctx); err != nil {
+		log.Fatalf("fx start: %v", err)
 	}
-	fmt.Printf("  📝 exchanges.yml\n")
+	defer func() { _ = app.Stop(ctx) }()
 
-	// Generate .gitignore if it doesn't exist
-	gitignorePath := filepath.Join(name, ".gitignore")
-	if _, err := os.Stat(gitignorePath); os.IsNotExist(err) {
-		gitignoreContent := `# Credentials
-exchanges.yml
+	if err := rt.StartStandalone(strat, *configDir, *wispPath); err != nil {
+		log.Fatalf("StartStandalone: %v", err)
+	}
 
-# Build artifacts
-*.so
-bin/
+	log.Println("running — Ctrl+C or Monitor → Stop")
+	if err := rt.Wait(); err != nil {
+		log.Printf("Wait: %v", err)
+		os.Exit(1)
+	}
+}
+`,
+		"strategy.go": fmt.Sprintf(`package main
 
-# IDE
-.vscode/
-.idea/
-*.swp
-*.swo
+import (
+	"context"
+	"time"
 
-# OS
-.DS_Store
-`
-		if err := os.WriteFile(gitignorePath, []byte(gitignoreContent), 0644); err != nil {
-			return fmt.Errorf("failed to write .gitignore: %w", err)
+	"github.com/wisp-trading/sdk/pkg/types/strategy"
+	"github.com/wisp-trading/sdk/pkg/types/wisp"
+)
+
+// Strategy is a minimal self-directed strategy (no orders).
+type Strategy struct {
+	strategy.BaseStrategy
+	k wisp.Wisp
+}
+
+func NewStrategy(k wisp.Wisp) strategy.Strategy {
+	s := &Strategy{k: k}
+	s.BaseStrategy = *strategy.NewBaseStrategy(strategy.BaseStrategyConfig{
+		Name: "%s",
+	})
+	return s
+}
+
+func (s *Strategy) Start(ctx context.Context) error {
+	return s.StartWithRunner(ctx, s.run)
+}
+
+func (s *Strategy) run(ctx context.Context) {
+	s.k.Log().Info("strategy running")
+	t := time.NewTicker(30 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			s.k.Log().Info("strategy stopped")
+			return
+		case <-t.C:
+			s.k.Log().Info("heartbeat")
 		}
-		fmt.Printf("  📝 .gitignore\n")
+	}
+}
+`, strategy),
 	}
 
+	for name, body := range files {
+		path := filepath.Join(strategyDir, name)
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", name, err)
+		}
+		fmt.Printf("  strategies/%s/%s\n", strategy, name)
+	}
+	return nil
+}
+
+func (s *scaffolder) writeProjectRoot(name, strategyExample string) error {
+	readme := fmt.Sprintf(`# %s
+
+Wisp strategy project.
+
+## Quick start
+
+1. **Keys** (once, global): run `+"`wisp`"+` → **Settings** → add Hyperliquid (or other) credentials  
+   Saved to `+"`~/.wisp/connectors.yml`"+` — shared by all strategies.
+2. **Deps:** `+"`cd strategies/%s && go mod tidy`"+`
+3. **Run:** from that directory: `+"`go run .`"+`  
+   Or from project root: `+"`wisp`"+` → **Strategies** → Start Live / **Monitor** → Stop
+
+## Layout
+
+`+"```"+`
+%s/
+└── strategies/
+    └── %s/
+        ├── main.go      # StartStandalone + Wait
+        ├── strategy.go
+        ├── config.yml   # exchanges/assets only (no secrets)
+        └── go.mod
+`+"```"+`
+
+Do not put API keys in this repo.
+`, name, strategyExample, name, strategyExample)
+
+	if err := os.WriteFile(filepath.Join(name, "README.md"), []byte(readme), 0o644); err != nil {
+		return err
+	}
+	fmt.Printf("  README.md\n")
+
+	gitignore := `# Never commit secrets
+.env
+.env.*
+
+# Strategy build artifacts
+strategies/*/*
+!strategies/*/*.go
+!strategies/*/*.yml
+!strategies/*/go.mod
+!strategies/*/go.sum
+strategies/*/*~
+*.so
+*.exe
+
+.DS_Store
+.idea/
+.vscode/
+`
+	if err := os.WriteFile(filepath.Join(name, ".gitignore"), []byte(gitignore), 0o644); err != nil {
+		return err
+	}
+	fmt.Printf("  .gitignore\n")
 	return nil
 }
 
 func (s *scaffolder) printSuccess(name, strategyExample string) {
 	blue := color.New(color.FgBlue)
-
-	fmt.Printf("\n✅ Project created successfully!\n\n")
-	fmt.Printf("Next steps:\n")
-	fmt.Printf("  %s\n", blue.Sprint("cd "+name))
-	fmt.Printf("  %s\n", blue.Sprint("go mod tidy"))
-	fmt.Printf("  %s\n", blue.Sprint(fmt.Sprintf("go run strategies/%s/strategy.go", strategyExample)))
-	fmt.Printf("\n")
-	fmt.Printf("📝 Important:\n")
-	fmt.Printf("  • Edit exchanges.yml to add your API credentials\n")
-	fmt.Printf("  • Configure strategy parameters in strategies/%s/config.yml\n", strategyExample)
+	fmt.Printf("\n✅ Project created\n\n")
+	fmt.Printf("Next:\n")
+	fmt.Printf("  1. %s   # Settings → add exchange keys → ~/.wisp/connectors.yml\n", blue.Sprint("wisp"))
+	fmt.Printf("  2. %s\n", blue.Sprint("cd "+filepath.Join(name, "strategies", strategyExample)+" && go mod tidy"))
+	fmt.Printf("  3. %s   # or: wisp → Strategies → Start Live\n", blue.Sprint("go run ."))
+	fmt.Printf("  4. %s   # Monitor → select → Stop\n", blue.Sprint("wisp"))
 }

--- a/internal/setup/services/scaffold_test.go
+++ b/internal/setup/services/scaffold_test.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateProjectWritesStandaloneStarter(t *testing.T) {
+	dir := t.TempDir()
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewScaffoldService()
+	if err := svc.CreateProject("demo_bot"); err != nil {
+		t.Fatal(err)
+	}
+
+	main := filepath.Join("demo_bot", "strategies", "starter", "main.go")
+	if _, err := os.Stat(main); err != nil {
+		t.Fatalf("missing main.go: %v", err)
+	}
+	cfg := filepath.Join("demo_bot", "strategies", "starter", "config.yml")
+	if _, err := os.Stat(cfg); err != nil {
+		t.Fatal(err)
+	}
+	// No credential files in project
+	for _, bad := range []string{
+		filepath.Join("demo_bot", "exchanges.yml"),
+		filepath.Join("demo_bot", "wisp.yml"),
+	} {
+		if _, err := os.Stat(bad); err == nil {
+			t.Fatalf("should not create %s", bad)
+		}
+	}
+	body, _ := os.ReadFile(main)
+	if !contains(string(body), "StartStandalone") || !contains(string(body), "Wait") {
+		t.Fatal("main.go must use StartStandalone + Wait")
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && (func() bool {
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+		return false
+	})())
+}


### PR DESCRIPTION
## Summary
Make the TUI path clear for the three jobs:

1. **Create New Project** — local starter with \`main.go\` / \`StartStandalone\`+\`Wait\` (no API keys in project)
2. **Settings** — exchange keys → \`~/.wisp/connectors.yml\` (empty first-run is fine)
3. **Strategies / Monitor** — start live + stop (unchanged path, clearer empty/help copy)

## Test plan
- [x] \`go test\` scaffold, settings, compile, manager
- [x] \`wisp init\` smoke creates starter layout
- [x] golangci-lint handlers/setup
- [ ] CI