### PR TITLE
fix(cli): Settings exit confirm + leave paths

### DIFF
--- a/internal/handlers/settings/form.go
+++ b/internal/handlers/settings/form.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
@@ -29,6 +30,9 @@ type ConnectorFormModel struct {
 
 	// UI state
 	showingDetail bool // true = show detail view, false = show edit form
+	// confirmExit is a modal over the edit form (ctrl+x / esc).
+	confirmExit   bool
+	confirmCursor int // 0 = stay, 1 = leave
 
 	// Form field values
 	exchangeName       string
@@ -219,12 +223,18 @@ func (m *ConnectorFormModel) buildForm() *huh.Form {
 		m.enabled = true // Default to enabled for new connectors
 	}
 
+	km := huh.NewDefaultKeyMap()
+	// Esc / ctrl+x abort the form (default Quit is only ctrl+c).
+	// Parent model intercepts these first for a confirm dialog when possible.
+	km.Quit = key.NewBinding(
+		key.WithKeys("ctrl+x", "ctrl+c", "esc"),
+		key.WithHelp("ctrl+x", "cancel"),
+	)
 	return huh.NewForm(groups...).
 		WithTheme(huh.ThemeCharm()).
 		WithShowHelp(true).
 		WithShowErrors(true).
-		// Tab / shift-tab between fields; Enter advances; Esc aborts.
-		WithKeyMap(huh.NewDefaultKeyMap())
+		WithKeyMap(km)
 }
 
 // minInt returns the minimum of two ints
@@ -255,54 +265,45 @@ func (m *ConnectorFormModel) Init() tea.Cmd {
 }
 
 func (m *ConnectorFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// Handle error state
+	// Error banner
 	if m.err != nil {
 		switch msg := msg.(type) {
 		case tea.KeyMsg:
-			if msg.String() == "esc" {
-				// Clear error and return to form
+			switch msg.String() {
+			case "esc", "enter":
 				m.err = nil
 				return m, nil
-			}
-			if msg.String() == "q" {
-				return m, m.router.Back()
+			case "q", "ctrl+x":
+				return m, m.leaveForm()
 			}
 		}
 		return m, nil
 	}
 
-	// Handle Ctrl+C to quit
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c":
-			return m, tea.Quit
-		}
+	// Modal: confirm discard / leave edit form
+	if m.confirmExit {
+		return m.updateConfirmExit(msg)
 	}
 
-	// If showing detail view
+	// Detail card
 	if m.showingDetail {
 		switch msg := msg.(type) {
 		case tea.KeyMsg:
 			switch msg.String() {
-			case "q", "esc":
+			case "q", "esc", "ctrl+x", "backspace":
 				return m, m.router.Back()
-			case "e":
-				// Switch to edit mode
+			case "e", "enter":
 				m.showingDetail = false
 				m.form = m.buildForm()
 				return m, m.form.Init()
 			case " ":
-				// Quick toggle enabled
 				m.connector.Enabled = !m.connector.Enabled
 				if err := m.config.UpdateConnector(m.connector); err != nil {
 					m.err = err
 					return m, nil
 				}
-				// Stay on detail view to see the change
 				return m, nil
 			case "d":
-				// Show delete confirmation dialog
 				deleteView := m.deleteFactory(m.connector.Name)
 				return m, bubblon.Open(deleteView)
 			}
@@ -310,23 +311,37 @@ func (m *ConnectorFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Editing mode - handle form
+	// Edit form: intercept leave keys before huh swallows them
+	if km, ok := msg.(tea.KeyMsg); ok {
+		switch km.String() {
+		case "ctrl+x", "esc":
+			m.confirmExit = true
+			m.confirmCursor = 0 // default Stay
+			return m, nil
+		case "ctrl+c":
+			// Same as leave — confirm first (don't hard-quit mid-edit)
+			m.confirmExit = true
+			m.confirmCursor = 0
+			return m, nil
+		}
+	}
+
+	if m.form == nil {
+		return m, nil
+	}
+
 	var cmd tea.Cmd
 	form, cmd := m.form.Update(msg)
 	if f, ok := form.(*huh.Form); ok {
 		m.form = f
 	}
 
-	// Check if form is complete
 	if m.form.State == huh.StateCompleted {
-		// Copy values from credentialPointers to credentials map
 		for fieldName, valuePtr := range m.credentialPointers {
 			if valuePtr != nil {
 				m.credentials[fieldName] = *valuePtr
 			}
 		}
-
-		// Build connector from form values
 		m.connector = config.Connector{
 			Name:        m.exchangeName,
 			Network:     m.network,
@@ -334,32 +349,62 @@ func (m *ConnectorFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			Assets:      m.assets,
 			Credentials: m.credentials,
 		}
-
-		// Save the connector
 		if err := m.saveConnector(); err != nil {
-			// Show error but allow user to go back or retry
-			m.err = fmt.Errorf("%w\n\nPress Esc to cancel or fix the values and submit again", err)
-			// Reset form state so user can edit
+			m.err = fmt.Errorf("%w\n\nEsc: fix form  ·  Ctrl+X: leave without saving", err)
 			m.form.State = huh.StateNormal
 			return m, nil
 		}
-
-		// Success - go back to list
 		return m, m.router.Back()
 	}
 
-	// Check if form was aborted (Esc pressed)
+	// huh Quit (if it still fires) → same confirm
 	if m.form.State == huh.StateAborted {
-		if m.isEditMode {
-			// Go back to detail view
-			m.showingDetail = true
-			return m, nil
-		}
-		// Adding new - go back to list
-		return m, m.router.Back()
+		m.form.State = huh.StateNormal
+		m.confirmExit = true
+		m.confirmCursor = 0
+		return m, nil
 	}
 
 	return m, cmd
+}
+
+func (m *ConnectorFormModel) updateConfirmExit(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "left", "h", "up", "k":
+			m.confirmCursor = 0
+		case "right", "l", "down", "j", "tab":
+			m.confirmCursor = 1
+		case "enter", " ":
+			if m.confirmCursor == 1 {
+				m.confirmExit = false
+				return m, m.leaveForm()
+			}
+			// Stay — resume form
+			m.confirmExit = false
+			return m, nil
+		case "n", "N", "esc":
+			m.confirmExit = false
+			return m, nil
+		case "y", "Y", "ctrl+x":
+			m.confirmExit = false
+			return m, m.leaveForm()
+		}
+	}
+	return m, nil
+}
+
+// leaveForm exits the form: detail view if editing, list if adding.
+func (m *ConnectorFormModel) leaveForm() tea.Cmd {
+	m.confirmExit = false
+	m.err = nil
+	if m.isEditMode {
+		m.showingDetail = true
+		m.form = nil
+		return nil
+	}
+	return m.router.Back()
 }
 
 func (m *ConnectorFormModel) saveConnector() error {
@@ -386,20 +431,43 @@ func (m *ConnectorFormModel) saveConnector() error {
 
 func (m *ConnectorFormModel) View() string {
 	if m.err != nil {
-		errorBox := ui.ErrorBoxStyle.Render("❌ " + m.err.Error())
-		return errorBox
+		return ui.ErrorBoxStyle.Render("❌ "+m.err.Error()) + "\n\n" +
+			ui.MutedStyle.Render("Esc fix  ·  Ctrl+X leave")
 	}
 
-	// Show detail view or edit form
 	if m.showingDetail {
 		return m.renderDetailView()
 	}
 
-	if m.form == nil {
-		return "Loading..."
+	base := "Loading..."
+	if m.form != nil {
+		base = m.form.View()
 	}
+	base += "\n" + ui.MutedStyle.Render("Tab next field  ·  Enter submit  ·  Ctrl+X / Esc cancel")
 
-	return m.form.View()
+	if m.confirmExit {
+		return m.renderConfirmExit(base)
+	}
+	return base
+}
+
+func (m *ConnectorFormModel) renderConfirmExit(under string) string {
+	stay := "  Stay  "
+	leave := "  Leave  "
+	if m.confirmCursor == 0 {
+		stay = ui.SelectedItemStyle.Render("[ Stay ]")
+		leave = ui.MutedStyle.Render("  Leave  ")
+	} else {
+		stay = ui.MutedStyle.Render("  Stay  ")
+		leave = ui.SelectedItemStyle.Render("[ Leave ]")
+	}
+	modal := ui.ErrorBoxStyle.Width(52).Render(
+		"Leave without saving?\n\n" +
+			"Unsaved credential edits will be discarded.\n\n" +
+			stay + "   " + leave + "\n\n" +
+			ui.MutedStyle.Render("←→ choose  ↵ confirm  y leave  n stay"),
+	)
+	return under + "\n\n" + modal
 }
 
 // renderDetailView shows a beautiful detail card for the connector

--- a/internal/handlers/settings/form_nav_test.go
+++ b/internal/handlers/settings/form_nav_test.go
@@ -1,0 +1,125 @@
+package settings
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wisp-trading/sdk/pkg/types/config"
+	"github.com/wisp-trading/sdk/pkg/types/connector"
+	"github.com/wisp-trading/wisp/internal/router"
+)
+
+type countRouter struct {
+	backs int
+}
+
+func (c *countRouter) Init() tea.Cmd                                  { return nil }
+func (c *countRouter) Update(msg tea.Msg) (tea.Model, tea.Cmd)        { return c, nil }
+func (c *countRouter) View() string                                   { return "" }
+func (c *countRouter) RegisterRoute(router.Route, router.ViewFactory) {}
+func (c *countRouter) NavigateTo(router.Route) tea.Cmd                { return nil }
+func (c *countRouter) Back() tea.Cmd {
+	c.backs++
+	return nil
+}
+func (c *countRouter) SetInitialView(tea.Model) {}
+
+type fieldSvc struct{}
+
+func (fieldSvc) GetMatchingConnectors() (map[connector.ExchangeName]config.Connector, error) {
+	return nil, nil
+}
+func (fieldSvc) ValidateConnectorConfig(connector.ExchangeName, config.Connector) error {
+	return nil
+}
+func (fieldSvc) MapToSDKConfig(config.Connector) (connector.Config, error) { return nil, nil }
+func (fieldSvc) GetConnectorConfigsForStrategy([]string) (map[connector.ExchangeName]connector.Config, error) {
+	return nil, nil
+}
+func (fieldSvc) GetRequiredCredentialFields(string) []string {
+	return []string{"private_key", "account_address"}
+}
+
+func TestFormCtrlXShowsConfirmThenLeave(t *testing.T) {
+	r := &countRouter{}
+	cfg := &stubConfig{}
+	m := &ConnectorFormModel{
+		config:       cfg,
+		connectorSvc: fieldSvc{},
+		router:       r,
+		isEditMode:   true,
+		exchangeName: "hyperliquid",
+		connector: config.Connector{
+			Name:    "hyperliquid",
+			Enabled: true,
+			Credentials: map[string]string{
+				"private_key":     "x",
+				"account_address": "y",
+			},
+		},
+		showingDetail: false,
+	}
+	m.form = m.buildForm()
+
+	// ctrl+x → confirm modal
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlX})
+	m = updated.(*ConnectorFormModel)
+	if !m.confirmExit {
+		t.Fatal("expected confirmExit after ctrl+x")
+	}
+
+	// choose Leave
+	m.confirmCursor = 1
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*ConnectorFormModel)
+	if m.confirmExit {
+		t.Fatal("confirm should close")
+	}
+	if !m.showingDetail {
+		t.Fatal("edit mode leave should return to detail view")
+	}
+}
+
+func TestFormConfirmStayKeepsForm(t *testing.T) {
+	r := &countRouter{}
+	m := &ConnectorFormModel{
+		config:        &stubConfig{},
+		connectorSvc:  fieldSvc{},
+		router:        r,
+		isEditMode:    true,
+		exchangeName:  "hyperliquid",
+		showingDetail: false,
+		confirmExit:   true,
+		confirmCursor: 0,
+		connector:     config.Connector{Name: "hyperliquid"},
+	}
+	m.form = m.buildForm()
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*ConnectorFormModel)
+	if m.confirmExit {
+		t.Fatal("stay should dismiss confirm")
+	}
+	if m.showingDetail {
+		t.Fatal("should remain on form")
+	}
+}
+
+func TestNewConnectorLeaveGoesBack(t *testing.T) {
+	r := &countRouter{}
+	m := &ConnectorFormModel{
+		config:        &stubConfig{},
+		connectorSvc:  fieldSvc{},
+		router:        r,
+		isEditMode:    false,
+		exchangeName:  "hyperliquid",
+		showingDetail: false,
+		confirmExit:   true,
+		confirmCursor: 1,
+	}
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*ConnectorFormModel)
+	_ = cmd
+	if r.backs != 1 {
+		t.Fatalf("expected Back() once, got %d", r.backs)
+	}
+}

--- a/internal/handlers/settings/list.go
+++ b/internal/handlers/settings/list.go
@@ -83,8 +83,8 @@ func (m *ConnectorListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "q":
-			// Navigate back to main menu
+		case "ctrl+c", "q", "esc", "ctrl+x", "backspace":
+			// Always allow leaving Settings → main menu
 			return m, m.router.Back()
 		case "up", "k":
 			if m.cursor > 0 {
@@ -281,6 +281,6 @@ func (m *ConnectorListModel) getHelpText() string {
 		ui.KeyHintStyle.Render("Enter"),
 		ui.KeyHintStyle.Render("d"),
 		ui.KeyHintStyle.Render("Space"),
-		ui.KeyHintStyle.Render("q"),
+		ui.KeyHintStyle.Render("q/Esc"),
 	)
 }

--- a/internal/handlers/walkthrough_test.go
+++ b/internal/handlers/walkthrough_test.go
@@ -1,0 +1,116 @@
+package handlers
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wisp-trading/sdk/pkg/types/config"
+	"github.com/wisp-trading/sdk/pkg/types/connector"
+	"github.com/wisp-trading/wisp/internal/handlers/settings"
+	"github.com/wisp-trading/wisp/internal/router"
+)
+
+// Lightweight walkthrough of model state machines (not full alt-screen).
+// Documents expected keyboard paths for the three core jobs.
+
+type wtRouter struct {
+	backs int
+	navs  []router.Route
+}
+
+func (w *wtRouter) Init() tea.Cmd                                  { return nil }
+func (w *wtRouter) Update(msg tea.Msg) (tea.Model, tea.Cmd)        { return w, nil }
+func (w *wtRouter) View() string                                   { return "" }
+func (w *wtRouter) RegisterRoute(router.Route, router.ViewFactory) {}
+func (w *wtRouter) NavigateTo(r router.Route) tea.Cmd {
+	w.navs = append(w.navs, r)
+	return nil
+}
+func (w *wtRouter) Back() tea.Cmd            { w.backs++; return nil }
+func (w *wtRouter) SetInitialView(tea.Model) {}
+
+type wtScaffold struct {
+	created string
+}
+
+func (s *wtScaffold) CreateProject(name string) error {
+	s.created = name
+	return nil
+}
+func (s *wtScaffold) CreateProjectWithStrategy(name, _ string) error {
+	return s.CreateProject(name)
+}
+
+func TestWalkthrough_MenuOpensCoreRoutes(t *testing.T) {
+	r := &wtRouter{}
+	m := mainMenuModel{
+		choices:  []string{"Strategies", "Monitor", "Settings", "Create New Project", "Help"},
+		router:   r,
+		scaffold: &wtScaffold{},
+	}
+	// Strategies
+	m.cursor = 0
+	_, _ = m.activate()
+	// Monitor
+	m.cursor = 1
+	_, _ = m.activate()
+	// Settings
+	m.cursor = 2
+	_, _ = m.activate()
+	if len(r.navs) != 3 {
+		t.Fatalf("navs=%v", r.navs)
+	}
+	if r.navs[0] != router.RouteStrategyList || r.navs[2] != router.RouteSettingsList {
+		t.Fatalf("unexpected routes %v", r.navs)
+	}
+}
+
+func TestWalkthrough_SettingsListEscBack(t *testing.T) {
+	r := &wtRouter{}
+	// Use real list model constructor
+	list := settings.NewSettingsListView(
+		&emptyCfg{},
+		&emptySvc{},
+		r,
+		func(string, bool) tea.Model { return nil },
+		func(string) tea.Model { return nil },
+	)
+	updated, _ := list.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	_ = updated
+	if r.backs != 1 {
+		t.Fatalf("esc should back out of settings, backs=%d", r.backs)
+	}
+	// q also
+	r.backs = 0
+	_, _ = list.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if r.backs != 1 {
+		t.Fatalf("q should back, backs=%d", r.backs)
+	}
+}
+
+type emptyCfg struct{}
+
+func (emptyCfg) LoadSettings(string) (*config.Settings, error) { return &config.Settings{}, nil }
+func (emptyCfg) GetConnectors() ([]config.Connector, error)    { return nil, nil }
+func (emptyCfg) GetEnabledConnectors() ([]config.Connector, error) {
+	return nil, nil
+}
+func (emptyCfg) SaveSettings(*config.Settings) error    { return nil }
+func (emptyCfg) AddConnector(config.Connector) error    { return nil }
+func (emptyCfg) UpdateConnector(config.Connector) error { return nil }
+func (emptyCfg) RemoveConnector(string) error           { return nil }
+func (emptyCfg) EnableConnector(string, bool) error     { return nil }
+
+type emptySvc struct{}
+
+func (emptySvc) GetMatchingConnectors() (map[connector.ExchangeName]config.Connector, error) {
+	return nil, nil
+}
+func (emptySvc) ValidateConnectorConfig(connector.ExchangeName, config.Connector) error {
+	return nil
+}
+func (emptySvc) MapToSDKConfig(config.Connector) (connector.Config, error) { return nil, nil }
+func (emptySvc) GetConnectorConfigsForStrategy([]string) (map[connector.ExchangeName]connector.Config, error) {
+	return nil, nil
+}
+func (emptySvc) GetRequiredCredentialFields(string) []string { return nil }


### PR DESCRIPTION
Ctrl+X/Esc confirm discard when editing keys; Settings list always leaveable.